### PR TITLE
Fixing the error convolution

### DIFF
--- a/pzflow/__init__.py
+++ b/pzflow/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 from .normalizing_flow import Flow

--- a/pzflow/normalizing_flow.py
+++ b/pzflow/normalizing_flow.py
@@ -241,7 +241,6 @@ class Flow:
             Looks for in `inputs` for columns with names ending in `_err`.
             I.e., the error for column `u` needs to be in the column `u_err`.
             Zero error assumed for any missing error columns.
-            WARNING: This is still experimental.
 
         Returns
         -------
@@ -252,8 +251,6 @@ class Flow:
             raise ValueError(
                 "Currently can only convolve error when using a Normal latent distribution."
             )
-        if convolve_err:
-            print("WARNING: Error convolution is still experimental.")
 
         if not convolve_err:
             # convert data to an array with columns ordered
@@ -305,7 +302,6 @@ class Flow:
             Looks for in `inputs` for columns with names ending in `_err`.
             I.e., the error for column `u` needs to be in the column `u_err`.
             Zero error assumed for any missing error columns.
-            WARNING: This is still experimental.
         batch_size : int, default=None
             Size of batches in which to calculate posteriors. If None, all
             posteriors are calculated simultaneously. Simultaneous calculation
@@ -320,8 +316,6 @@ class Flow:
             raise ValueError(
                 "Currently can only convolve error when using a Normal latent distribution."
             )
-        if convolve_err:
-            print("WARNING: Error convolution is still experimental.")
 
         # get the index of the provided column, and remove it from the list
         columns = list(self.data_columns)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras = {
 
 setup(
     name="pzflow",
-    version="1.5.0",
+    version="1.5.1",
     author="John Franklin Crenshaw",
     author_email="jfc20@uw.edu",
     description="Probabilistic modeling of tabular data with normalizing flows.",

--- a/tests/test_normalizing_flow.py
+++ b/tests/test_normalizing_flow.py
@@ -122,7 +122,7 @@ def test_jacobian():
     J = flow._jacobian(flow._params, xarray, conditions=conditions)
     assert np.allclose(
         J,
-        np.array([[[0, 0.5], [0.5, 0]], [[0, 0.5], [0.5, 0]], [[0, 0.5], [0.5, 0]]]),
+        np.array([[[0, 2.0], [2.0, 0]], [[0, 2.0], [2.0, 0]], [[0, 2.0], [2.0, 0]]]),
     )
 
 

--- a/tests/test_normalizing_flow.py
+++ b/tests/test_normalizing_flow.py
@@ -75,6 +75,10 @@ def test_error_convolution():
     flow = Flow(("redshift", "y"), Reverse(), latent=Normal(2))
 
     assert flow.log_prob(x, convolve_err=True).shape == (x.shape[0],)
+    assert np.allclose(
+        flow.log_prob(x, convolve_err=True),
+        flow.log_prob(x, convolve_err=False),
+    )
 
     grid = np.arange(0, 2.1, 0.12)
     pdfs = flow.posterior(x, column="y", grid=grid, convolve_err=True)


### PR DESCRIPTION
At some point I accidentally broke the error convolution - posteriors always returned zeros. Found there were a few problems. The one's I remember off the top of my head:
- Was differentiating inverse instead of forward (this is a holdover from when the bijection was defined in the opposite direction)
- The mahalanobis calculation wasn't correctly broadcasting across the covariance matrices for each input.