### PR TITLE
(maint) smol changes

### DIFF
--- a/pzflow/normalizing_flow.py
+++ b/pzflow/normalizing_flow.py
@@ -70,17 +70,17 @@ class Flow:
         # validate parameters
         if data_columns is None and bijector is None and file is None:
             raise ValueError("You must provide data_columns and bijector OR file.")
-        elif data_columns is not None and bijector is None:
+        if data_columns is not None and bijector is None:
             raise ValueError("Please also provide a bijector.")
-        elif data_columns is None and bijector is not None:
+        if data_columns is None and bijector is not None:
             raise ValueError("Please also provide data_columns.")
-        elif file is not None and any(
+        if file is not None and any(
             (
-                data_columns != None,
-                bijector != None,
-                conditional_columns != None,
-                latent != None,
-                info != None,
+                data_columns is not None,
+                bijector is not None,
+                conditional_columns is not None,
+                latent is not None,
+                info is not None,
             )
         ):
             raise ValueError(
@@ -124,7 +124,7 @@ class Flow:
 
             # set up the latent distribution
             if latent is None:
-                self.latent = getattr(distributions, "Normal")(self._input_dim)
+                self.latent = distributions.Normal(self._input_dim)
             else:
                 self.latent = latent
             self._latent_info = self.latent.info
@@ -264,13 +264,12 @@ class Flow:
             conditions = self._get_conditions(inputs, len(inputs))
             # calculate log_prob
             return self._log_prob(self._params, X, conditions)
-        else:
-            # convert data to an array with columns ordered
-            X = self._array_with_errs(inputs)
-            # get conditions
-            conditions = self._get_conditions(inputs, len(inputs))
-            # calculate log_prob
-            return self._log_prob_convolved(self._params, X, conditions)
+        # convert data to an array with columns ordered
+        X = self._array_with_errs(inputs)
+        # get conditions
+        conditions = self._get_conditions(inputs, len(inputs))
+        # calculate log_prob
+        return self._log_prob_convolved(self._params, X, conditions)
 
     def posterior(
         self,

--- a/pzflow/utils.py
+++ b/pzflow/utils.py
@@ -15,8 +15,7 @@ def build_bijector_from_info(info):
     if info[0] == "Chain":
         return bijectors.Chain(*(build_bijector_from_info(i) for i in info[1]))
     # build individual bijector from name and parameters
-    else:
-        return getattr(bijectors, info[0])(*info[1])
+    return getattr(bijectors, info[0])(*info[1])
 
 
 def DenseReluNetwork(


### PR DESCRIPTION
### Use identity check for comparison to a singleton

Comparisons to the singleton objects, like True, False, and None, should
be done with identity, not equality.  Identity checks are faster than equality
checks. Also, the equality checks can result in unintended behavior in some
cases. Saw your use of identity checks elsewhere in `pzflow`.

### Refactor unnecessary `else` / `elif` when `if` block has a `return` or `raise` statement

  `return` statement causes the control flow to be disrupted, making the
  `else` / `elif` blocks here unnecessary. This doesn't mean you can not use
  it, but I'd recommended refactoring this for better readability.

### Access attribute directly

  Pretty sure you can get rid of the just get the `_input_dim` instance variable
  directly here.

---

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>