### PR TITLE
Default B=5 in splines

### DIFF
--- a/examples/spherical_flow_example.ipynb
+++ b/examples/spherical_flow_example.ipynb
@@ -352,11 +352,11 @@
    "source": [
     "Before we talk about the bijector, let's create the latent distribution.\n",
     "\n",
-    "We are going to use $\\mathcal{U}(-3, 3)$ for the latent distribution of $\\cos(\\theta)$ and $\\phi$. \n",
+    "We are going to use $\\mathcal{U}(-5, 5)$ for the latent distribution of $\\cos(\\theta)$ and $\\phi$. \n",
     "As a reminder -- we are using uniform distributions because distributions that match the compact support of $\\cos(\\theta)$ and $\\phi$.\n",
     "\n",
-    "It may seem confusing why I chose $[-3, +3]$ for both, instead of $[-1, +1]$ and $[0, 2\\pi]$.\n",
-    "This is because in the bijector we will use Neural Spline Couplings (see below), whose default extent is $[-3, +3]$ (i.e. `B=3` by default). So it makes sense to choose a latent distribution that takes full advantage of this range.\n",
+    "It may seem confusing why I chose $[-5, +5]$ for both, instead of $[-1, +1]$ and $[0, 2\\pi]$.\n",
+    "This is because in the bijector we will use Neural Spline Couplings (see below), whose default extent is $[-5, +5]$ (i.e. `B=5` by default). So it makes sense to choose a latent distribution that takes full advantage of this range.\n",
     "\n",
     "For `logpop` we can just use a regular Normal distribution, like we have before.\n",
     "\n",
@@ -369,7 +369,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "latent = Joint(Uniform((-3,3), (-3,3)), Normal(1))"
+    "latent = Joint(Uniform((-5,5), (-5,5)), Normal(1))"
    ]
   },
   {
@@ -404,7 +404,7 @@
    "outputs": [],
    "source": [
     "means = np.array([np.pi, 0, data['logpop'].mean()])\n",
-    "stds = np.array([np.pi/3, 1/3, data['logpop'].std()])\n",
+    "stds = np.array([np.pi/5, 1/5, data['logpop'].std()])\n",
     "\n",
     "bijector = Chain(\n",
     "    StandardScaler(means, stds), \n",
@@ -536,8 +536,8 @@
    "source": [
     "# sample from the raw latent distribution\n",
     "latent_samples = flow.latent.sample(flow.latent._params, data.shape[0], seed=0)\n",
-    "latent_theta = np.arccos(latent_samples[:,0]/3)\n",
-    "latent_phi = latent_samples[:,1]*(np.pi/3)\n",
+    "latent_theta = np.arccos(latent_samples[:,0]/5)\n",
+    "latent_phi = latent_samples[:,1]*(np.pi/5)\n",
     "latent_logpop = (latent_samples[:,2] * data['logpop'].std() + data['logpop'].mean()).astype(float)\n",
     "\n",
     "# sample from the trained flow\n",

--- a/pzflow/bijectors/neural_splines.py
+++ b/pzflow/bijectors/neural_splines.py
@@ -177,7 +177,7 @@ def _RationalQuadraticSpline(
 @Bijector
 def NeuralSplineCoupling(
     K: int = 16,
-    B: float = 3,
+    B: float = 5,
     hidden_layers: int = 2,
     hidden_dim: int = 128,
     transformed_dim: int = None,
@@ -201,9 +201,11 @@ def NeuralSplineCoupling(
     ----------
     K : int, default=16
         Number of bins in the spline (the number of knots is K+1).
-    B : float, default=3
+    B : float, default=5
         Range of the splines.
-        Outside of (-B,B), the transformation is just the identity.
+        If periodic=False, outside of (-B,B), the transformation is just
+        the identity. If periodic=True, the input is mapped into the
+        appropriate location in the range (-B,B).
     hidden_layers : int, default=2
         The number of hidden layers in the neural network used to calculate
         the positions and derivatives of the spline knots.
@@ -314,7 +316,7 @@ def RollingSplineCoupling(
     nlayers: int,
     shift: int = 1,
     K: int = 16,
-    B: float = 3,
+    B: float = 5,
     hidden_layers: int = 2,
     hidden_dim: int = 128,
     transformed_dim: int = None,
@@ -331,8 +333,11 @@ def RollingSplineCoupling(
         How far the inputs are shifted on each Roll().
     K : int, default=16
         Number of bins in the RollingSplineCoupling.
-    B : float, default=3
+    B : float, default=5
         Range of the splines in the RollingSplineCoupling.
+        If periodic=False, outside of (-B,B), the transformation is just
+        the identity. If periodic=True, the input is mapped into the
+        appropriate location in the range (-B,B).
     hidden_layers : int, default=2
         The number of hidden layers in the neural network used to calculate
         the bins and derivatives in the RollingSplineCoupling.


### PR DESCRIPTION
Made extent of splines default to 5 (i.e. `B=5`). This is so their extent covers a 5-sigma range for a Normal distribution. This will reduce the number of weird artifacts when you sample a ton of times from a flow with a Normal latent distribution. Note that because the splines have a compact domain for transformation, it would probably be prudent to phase out Normal latent distributions altogether...